### PR TITLE
テーマで利用する @vivliostyle/theme-techbook と @vivliostyle/theme-base を 1.0.1 に固定する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dist
 
 # vivliostyle
 .vivliostyle
+book
+book.pdf

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
-        "@vivliostyle/theme-base": "latest",
-        "@vivliostyle/theme-techbook": "latest"
+        "@vivliostyle/theme-base": "1.0.1",
+        "@vivliostyle/theme-techbook": "1.0.1"
       },
       "devDependencies": {
         "@vivliostyle/cli": "^8.3.0",
@@ -1064,6 +1064,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@vivliostyle/theme-base/-/theme-base-1.0.1.tgz",
       "integrity": "sha512-N5Fa6j6gQFzIvk8uqhwGyRfz/IBzuJRCWq9s0CDN1XB0tr2K2S+E268emoiXdXxRe70enBOR53dADEdEP1Y4JA==",
+      "license": "CC0-1.0",
       "peerDependencies": {
         "@vivliostyle/cli": ">=7"
       },
@@ -1077,6 +1078,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@vivliostyle/theme-techbook/-/theme-techbook-1.0.1.tgz",
       "integrity": "sha512-u3zaJV5eDgGjl6PJWfZaM1TlFKLksFLTJxic0WTWWYTr1MoDdxfTBAU5THLqJdeYurumg6WiLCNvvuVmL2fbZw==",
+      "license": "CC0-1.0",
       "dependencies": {
         "@vivliostyle/theme-base": "^1.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "validate": "vivliostyle-theme-scripts validate"
   },
   "dependencies": {
-    "@vivliostyle/theme-base": "latest",
-    "@vivliostyle/theme-techbook": "latest"
+    "@vivliostyle/theme-base": "1.0.1",
+    "@vivliostyle/theme-techbook": "1.0.1"
   },
   "devDependencies": {
     "@vivliostyle/cli": "^8.3.0",


### PR DESCRIPTION
## 背景＆目的

- 先日、@vivliostyle/theme-techbook と @vivliostyle/theme-base が 2.0.0 に更新された
- [@vivliostyle/theme-base](https://github.com/vivliostyle/themes/blob/main/packages/%40vivliostyle/theme-base/CHANGELOG.md) の変更により、大技林テーマに影響がでた
- 当面の対応として、テーマを1.0.1に固定して、問題を回避したい

## 変更点

- package.json で指定するバージョンを `latest` から `1.0.1` にしました

## 検証

- このリポジトリのexampleで `npm run build` して、1.0.1 が取り込まれているのを確認した

|before|after|
| --- | --- |
| <img width="1536" alt="スクリーンショット 2024-12-20 19 06 27" src="https://github.com/user-attachments/assets/5cbd1a87-b356-4568-9f2f-598db532fe9c" />  |<img width="1536" alt="スクリーンショット 2024-12-20 19 07 17" src="https://github.com/user-attachments/assets/ba48e01b-7beb-491a-9c8a-21bb9fe2647f" />  |

## その他

- `npm run build` で作られる book/ および book.pdf はコミット不要なので gitignore に追加しました

