### PR TITLE
目次のスタイルを改善

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -74,8 +74,8 @@
    * toc
    */
   --vs-toc--marker-content: counter(vs-counter-toc) '.';
-  --vs-toc--marker-display: block;
-  --vs-toc--marker-text-align: end;
+  --vs-toc--marker-display: inline-block;
+  --vs-toc--ol-indent-size: 1.5rem;
 
   /* 
    * page's margins
@@ -84,6 +84,23 @@
   --vs-page--margin-bottom: 25mm;
   --vs-page--margin-inner: 17mm;
   --vs-page--margin-outer: 17mm;
+}
+
+/* 
+ * toc
+ */
+#toc,
+[role='doc-toc'] {
+  --vs--ol-minimum-inline-indent-size: revert;
+}
+
+:is(#toc, [role='doc-toc']) li::before {
+  inline-size: auto;
+  inset-inline-start: 0;
+}
+
+:is(#toc, [role='doc-toc']) ol {
+  padding-inline-start: 20px;
 }
 
 /* 


### PR DESCRIPTION

## 変更内容

- 目次（TOC）のスタイルを改善
  - マーカーの表示方法を `block` から `inline-block` に変更
  - 目次のインデントサイズを `1.5rem` に設定
  - 目次の余白やレイアウトを調整

## 変更理由

- 目次のレイアウトを改善し、より読みやすく使いやすい形式に調整

## 技術的な詳細

- CSSカスタムプロパティを使用して目次のスタイルを定義
- 目次要素（`#toc`および`[role='doc-toc']`）に対する具体的なスタイル調整

## 確認項目

- [ ] 目次のスタイルが意図通りに表示されているか
- [ ] 既存のスタイルに影響を与えていないか