### PR TITLE
URLの数だけ脚注番号が進まないようにする

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -140,6 +140,10 @@ figure img {
  * footnote-external-link
  */
 @media print {
+  :not(.footnote) > a[href^='http'] {
+    counter-increment: none;
+  }
+
   :not(.footnote)>a[href^='http']::before {
     display: none;
   }


### PR DESCRIPTION
素晴らしいテーマを公開いただき、ありがとうございます。

こちらを使う中で、URLの数だけ**脚注番号が飛ぶ**ことに気づきました。
theme-baseテーマにあるカウンタを加算しないようにすることで脚注番号が飛ばなくなると思いますので、プルリクエストを送ります

## before: 脚注番号が飛ぶ

```markdown
from Wikipedia <https://en.wikipedia.org/wiki/JavaScript>

https://example.com/

「さよなら。」って、その子は花<span class="footnote">この部分が脚注になります。</span>に言った。
```

<img width="424" height="121" alt="image" src="https://github.com/user-attachments/assets/5885eb9e-fece-4db0-a722-f525400a3468" />

URLに脚注番号1,2があたるので、脚注が（1ではなく）3から始まります。

## after: 脚注番号が飛ばない

<img width="408" height="118" alt="image" src="https://github.com/user-attachments/assets/43da2203-e207-4c30-b7ac-ed9e6de3750e" />

vivliostyle-theme-macneko-techbookと一緒に使えるカスタムCSSを見つけました。
最小のプロジェクト例：https://github.com/ftnext/sphinx-playground/tree/255d9f7145ecf5a1bb31aa601f3b9eeae1eb5895/vivliostyle/mybook

```css
@media print {
  :not(.footnote) > a[href^='http'] {
    counter-increment: none;
  }
}
```

こちらをテーマ自体に含められると他の方も嬉しいのではと思い、プルリクエストをお送りしました